### PR TITLE
Send missing variables to the TIMS template

### DIFF
--- a/tims.module
+++ b/tims.module
@@ -50,6 +50,23 @@ function tims_init() {
     $info['function'] = 'tims_render';
     $info['theme path'] = drupal_get_path('module', 'tims') . '/theme';
     $info['process functions'][] = 'tims_set_template';
+    
+    foreach ($theme_registry_array as $key=>$item) {
+      if (!isset($item['pattern'])) {
+        //We only want items with patterns... maybe?  (trying to be super conservative here so that we don't break anything)
+        //I'm also not sure how to get the closest match if there are unspecific patterns...
+        continue;
+      }
+      
+      if (strpos($hook, $item['pattern']) !== 0) {
+        //Make sure that the pattern matches (again, I haven't thought about specificity yet)
+        continue;
+      }
+
+      //We should merge all of the regsitry items into our new one so that all
+      //normal preprocess functions are called.
+      $info = array_merge_recursive($item, $info);
+    }
 
     $theme_registry_object[$hook] = $theme_registry_array[$hook] = $info;
   }

--- a/tims.module
+++ b/tims.module
@@ -51,21 +51,33 @@ function tims_init() {
     $info['theme path'] = drupal_get_path('module', 'tims') . '/theme';
     $info['process functions'][] = 'tims_set_template';
     
-    foreach ($theme_registry_array as $key=>$item) {
-      if (!isset($item['pattern'])) {
-        //We only want items with patterns... maybe?  (trying to be super conservative here so that we don't break anything)
-        //I'm also not sure how to get the closest match if there are unspecific patterns...
-        continue;
+    
+    // Use the drupal theme() logic for determining the closest match
+    // If there's no implementation, check for more generic fallbacks.
+    $match = $hook;
+    if (!isset($theme_registry_array[$match])) {
+      // Iteratively strip everything after the last '__' delimiter, until an
+      // implementation is found.
+      while ($pos = strrpos($match, '__')) {
+        $match = substr($match, 0, $pos);
+        if (isset($theme_registry_array[$match])) {
+          if (isset($theme_registry_array[$match]['function']) 
+            && $theme_registry_array[$match]['function'] == 'tims_render') {
+            //Don't merge our own TIMS hooks
+            continue;
+          }
+          
+          //We found a match!
+          break;
+        }
       }
-      
-      if (strpos($hook, $item['pattern']) !== 0) {
-        //Make sure that the pattern matches (again, I haven't thought about specificity yet)
-        continue;
-      }
+      if (isset($theme_registry_array[$match])) {
+        //Only merge the hook if it exists
 
-      //We should merge all of the regsitry items into our new one so that all
-      //normal preprocess functions are called.
-      $info = array_merge_recursive($item, $info);
+        //We should merge all of the regsitry items into our new one so that all
+        //normal preprocess functions are called.
+        $info = array_merge_recursive($theme_registry_array[$match], $info);
+      }
     }
 
     $theme_registry_object[$hook] = $theme_registry_array[$hook] = $info;


### PR DESCRIPTION
I've descovered, and I know @ericras has too, that not all variables make it to the TIMS template.  A specific example of this is the `views_view` template seen here: https://api.drupal.org/api/views/theme!views-view.tpl.php/7

In TIMS, none of those contextual variables are available, which makes the template useless.

I've discovered that this is because of the way that we are altering the theme registry.

The theme registry has an item for `views_view` which is as follows:

```
[views_view] => Array
        (
            [pattern] => views_view__
            [file] => theme.inc
            [path] => sites/all/modules/views/theme
            [variables] => Array
                (
                    [view_array] => Array
                        (
                        )

                    [view] => 
                )

            [template] => views-view
            [type] => module
            [theme path] => sites/all/modules/views
            [includes] => Array
                (
                    [0] => sites/all/modules/views/theme/theme.inc
                )

            [preprocess functions] => Array
                (
                    [0] => template_preprocess
                    [1] => template_preprocess_views_view
                    [2] => contextual_preprocess
                    [3] => views_ui_preprocess_views_view
                )

            [process functions] => Array
                (
                    [0] => template_process
                    [1] => template_process_views_view
                    [2] => ctools_process
                )

        )
```

Then, the TIMS module adds its own entry like this:

```
[views_view__test__page] => Array
        (
            [function] => tims_render
            [theme path] => sites/all/modules/tims/theme
            [process functions] => Array
                (
                    [0] => tims_set_template
                )

        )
```

Thus, we have lost the process and preprocess hooks along with other important information.

So, this change merges the two so that it becomes:

```
Array
(
    [pattern] => views_view__
    [file] => theme.inc
    [path] => sites/all/modules/views/theme
    [variables] => Array
        (
            [view_array] => Array
                (
                )

            [view] => 
        )

    [template] => views-view
    [type] => module
    [theme path] => Array
        (
            [0] => sites/all/modules/views
            [1] => sites/all/modules/tims/theme
        )

    [includes] => Array
        (
            [0] => sites/all/modules/views/theme/theme.inc
        )

    [preprocess functions] => Array
        (
            [0] => template_preprocess
            [1] => template_preprocess_views_view
            [2] => contextual_preprocess
            [3] => views_ui_preprocess_views_view
        )

    [process functions] => Array
        (
            [0] => template_process
            [1] => template_process_views_view
            [2] => ctools_process
            [3] => tims_set_template
        )

    [function] => tims_render
)
```

I'm not very familiar with how all of this works, and I'm not quite sure how to know which entry to merge in the case where there are multiple hook patterns that match.  I'm also only doing this for entries with patterns, but I think it should be okay to do it to everything?

Any thoughts/feedback is welcome.
